### PR TITLE
ci(gha): migrate release workflow from circleci

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   publish-manifest:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,11 @@
-name: Release Notification
+name: Publish
 
 on:
   release:
     types: [published]
 
 jobs:
-  release-manifest:
+  publish-manifest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,15 +27,15 @@ jobs:
       - name: Update SDK Manifests
         run: ./Scripts/UpdateManifests.bash ${{ github.ref_name }} $CHECKSUM
 
-      # - name: Commit and Push
-      #   run: |
-      #     git config --global user.email "$SRE_EMAIL"
-      #     git config --global user.name "GitHub Bot"
-      #     git add Package.swift FlowplayerSDK.podspec
-      #     git commit -m "release: ${{ github.ref_name }}"
-      #     git push origin main
+      - name: Commit and Push
+        run: |
+          git config --global user.email "$SRE_EMAIL"
+          git config --global user.name "GitHub Bot"
+          git add Package.swift FlowplayerSDK.podspec
+          git commit -m "release: ${{ github.ref_name }}"
+          git push origin main
 
-  release-cocoapods:
+  publish-cocoapods:
     runs-on: ubuntu-latest
     needs: release-manifest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release asset from public repo
+        run: |
+          gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          ${{ github.repository }}/FlowplayerSDK.zip
+
+      - name: Calculate new checksum
+        run: |
+          echo "CHECKSUM=$(shasum -a 256 FlowplayerSDK.zip | awk '{print $1}')" >> $BASH_ENV
+
+      - name: Make UpdateManifests script executable
+        run: chmod +x ./Scripts/UpdateManifests.bash
+
+      - name: Update SDK Manifests
+        run: ./Scripts/UpdateManifests.bash ${{ github.ref_name }} $CHECKSUM
+
+      # - name: Commit and Push
+      #   run: |
+      #     git config --global user.email "$SRE_EMAIL"
+      #     git config --global user.name "GitHub Bot"
+      #     git add Package.swift FlowplayerSDK.podspec
+      #     git commit -m "release: ${{ github.ref_name }}"
+      #     git push origin main
+
+  release-cocoapods:
+    runs-on: ubuntu-latest
+    needs: release-manifest
+    steps:
+      - uses: actions/checkout@v4


### PR DESCRIPTION
Adds a new Github action which automatically updates the package manager manifests and publishes them. 