### PR TITLE
fix(PLAY-983): Trigger the release publish from this repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: DEBUG
+        run: ls -al
+
       - name: Calculate new checksum
         run: |
           echo "CHECKSUM=$(shasum -a 256 FlowplayerSDK.zip | awk '{print $1}')" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,9 +25,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
-      - name: DEBUG
-        run: ls -al
-
       - name: Calculate new checksum
         run: |
           echo "CHECKSUM=$(shasum -a 256 FlowplayerSDK.zip | awk '{print $1}')" >> $GITHUB_ENV

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,16 @@
 name: Publish
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag associated with the release"
+        required: true
+        type: string
+      changelog:
+        description: "Changelog associated with the release"
+        required: true
+        type: string
 
 jobs:
   publish-manifest:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,8 +43,32 @@ jobs:
           git commit -m "release: v${{ inputs.tag }}"
           git push origin main
 
-  publish-cocoapods:
+      - name: Persist workspace artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-zip
+          path: |
+            FlowplayerSDK.zip
+            Documentation.zip
+
+  publish_release:
     runs-on: ubuntu-latest
     needs: publish-manifest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get persisted artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts-zip
+
+      - name: Publish public release
+        run: gh release create ${{ inputs.tag }} FlowplayerSDK.zip Documentation.zip -t "v${{ inputs.tag }}" --notes ${{ inputs.changelog }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  publish-cocoapods:
+    runs-on: ubuntu-latest
+    needs: publish_release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,11 +18,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download release asset from public repo
+      - name: Download release asset from private repo
         run: |
-          gh release download --pattern 'FlowplayerSDK.zip'
+          gh release download --pattern '*.zip' --repo ${{ secrets.PRIVATE_REPO }}
+          ls -al
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PRIVATE_REPO_TOKEN }}
 
       - name: DEBUG
         run: ls -al

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,14 +33,14 @@ jobs:
         run: chmod +x ./Scripts/UpdateManifests.bash
 
       - name: Update SDK Manifests
-        run: ./Scripts/UpdateManifests.bash ${{ github.ref_name }} ${{ env.CHECKSUM }}
+        run: ./Scripts/UpdateManifests.bash ${{ inputs.tag }} ${{ env.CHECKSUM }}
 
       - name: Commit and Push
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Bot"
           git add Package.swift FlowplayerSDK.podspec
-          git commit -m "release: ${{ github.ref_name }}"
+          git commit -m "release: v${{ inputs.tag }}"
           git push origin main
 
   publish-cocoapods:

--- a/Scripts/UpdateManifests.bash
+++ b/Scripts/UpdateManifests.bash
@@ -7,29 +7,28 @@ if [ $# -eq 0 ]; then
 fi
 
 # Assuming this script is executed from directory which contains Package.Swift
-# take version (e.g. 4.0.0) as argument
-# take checksum as argument
+# Version (e.g. 4.0.0) as argument
 NEW_VERSION=$1
+# Checksum as argument
 NEW_CHECKSUM=$2
 
+echo "New checksum is: $NEW_CHECKSUM"
+echo "New version is: $NEW_VERSION"
+
+# Update Package.swift
 echo "Updating Package.swift..."
-echo "🔐 New checksum is: $NEW_CHECKSUM"
-
-# Replace version information in package manifest
 sed -E -i '' 's/let version = ".+"/let version = "'$NEW_VERSION\"/ Package.swift
-
-# Replace checksum information in package manifest
 sed -i -E "s/checksum: \".*\"/checksum: \"$NEW_CHECKSUM\"/" Package.swift
-
-# print out package manifes for convenience reasons
-echo "📜 New Package Manifest is:"
+echo "New Package.swift:"
 cat Package.swift
 
-echo "💊 Updating FlowplayerSDK.podspec..."
+# Update CocoaPods
+echo "Updating FlowplayerSDK.podspec"
 sed -E -i '' 's/VERSION = ".+"/VERSION = "'$NEW_VERSION\"/ FlowplayerSDK.podspec
+echo "New FlowplayerSDK.podspec"
+cat FlowplayerSDK.podspec
 
-# Check if the file exists and delete it if it does
+# Remove generated Package.swift-E
 if [ -f "Package.swift-E" ]; then
     rm "Package.swift-E"
 fi
-


### PR DESCRIPTION
This issue addresses a critical issue related to Swift Package Manager (SPM) releases. Currently, the release process involves creating the Git release before updating the `Package.swift` file. This results in the Git tag being associated with an outdated `Package.swift` version and checksum, leading to inconsistencies and potential errors. To resolve this, we will refactor the release process to trigger the release from this public repository using `workflow_dispatch`. The new public repository GitHub Actions workflow will download artifacts from the private repository, update the `Package.swift` file with the new tag and checksum, and then create the tagged Git release. This ensures the release is triggered after the `Package.swift` has been committed and the checksum has been generated correctly.